### PR TITLE
Fix workflow for actions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,6 +1,11 @@
 name: GitHub Actions Test
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  repository_dispatch:
+    types: [batch-trigger]
 
 jobs:
   test:
@@ -11,6 +16,7 @@ jobs:
     env:
       MATHWORKS_LICENSING_ENDPOINT: ${{ matrix.stage }}
     steps:
+      - uses: actions/checkout@v2
       - name: Set up MATLAB
         run: wget -qO- --retry-connrefused "https://ssd.mathworks.com/supportfiles/ci/ephemeral-matlab/v0/ci-install.sh" | sudo -E bash
       - name: Run tests

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -32,8 +32,8 @@ jobs:
     - name: Trigger GitHub Actions build
       run: |
         curl --request POST \
-          --url https://api.github.com/repos/mathworks-continuous-integration/ci-test/actions/workflows/actions.yml/dispatches \
+          --url https://api.github.com/repos/mathworks-continuous-integration/ci-test/dispatches \
           --header 'accept: application/vnd.github.v3+json' \
           --header 'authorization: Bearer ${{ secrets.ACTIONS_TOKEN }}' \
           --header 'content-type: application/json' \
-          --data '{"ref": "main"}'
+          --data '{"event_type": "batch-trigger"}'

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -34,6 +34,6 @@ jobs:
         curl --request POST \
           --url https://api.github.com/repos/mathworks-continuous-integration/ci-test/actions/workflows/actions.yml/dispatches \
           --header 'accept: application/vnd.github.v3+json' \
-          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          --header 'authorization: Bearer ${{ secrets.ACTIONS_TOKEN }}' \
           --header 'content-type: application/json' \
           --data '{"ref": "main"}'


### PR DESCRIPTION
Turns out the GITHUB_TOKEN that is supplied with a workflow doesn't have the ability to trigger workflows :/
So now the workflow is updated to use a different token